### PR TITLE
issue49 l2 fail through pythonrun

### DIFF
--- a/host/tests/rmfAudioClasses/rmfAudio.py
+++ b/host/tests/rmfAudioClasses/rmfAudio.py
@@ -117,7 +117,7 @@ class rmfAudioClass():
         Returns:
             bool: True - test pass, False - test fails
         """
-        output = self.utMenu.select( self.testSuite, test_case)
+        output = self.utMenu.select( self.testSuite, test_case, None, 25)
         results = self.utMenu.collect_results(output)
         if results == None:
             results = False


### PR DESCRIPTION
Issue raised in element..
 
When I executed the testcase manually observed it takes more than 10 sec to complete.
whereas executing with python observed the test gets the result even before the testcase is completed and results as failed.
This is because in framework the select method has timeout value as 10 so it exists within 10 sec with the available result.
**def select(self, suite_name: str, test_name:str = None, promptWithAnswers:dict = None, timeout:int = 10)**
 
When I increased the value from the rmfAudio.py class Line120 , it works as expected 
**output = self.utMenu.select( self.testSuite, test_case, None, 25)**